### PR TITLE
Prevent Login Requests from being sent twice

### DIFF
--- a/components/Index/Login.vue
+++ b/components/Index/Login.vue
@@ -33,7 +33,6 @@
           <button
             class="hoveranimation btn btn-primary w-full"
             type="submit"
-            @click="submitLoginRequest"
           >
             {{ $t('login') }}
           </button>


### PR DESCRIPTION
Currently, clicking the Login button sends two identical requests
one from the form and one from the login button itself
